### PR TITLE
Add numeric value display below EAN13 barcode

### DIFF
--- a/EAN13View/Source/EAN13.swift
+++ b/EAN13View/Source/EAN13.swift
@@ -6,7 +6,7 @@ public struct EAN13{
     
     let lines: [Bool]
     
-    private let value: String
+    public let value: String
     private let validator = EAN13Validator()
     
     public init(value: String) throws {

--- a/EAN13View/Source/EAN13View.swift
+++ b/EAN13View/Source/EAN13View.swift
@@ -11,3 +11,43 @@ extension UIStackView{
         distribution = .fillEqually
     }
 }
+
+public class EAN13View: UIView {
+    
+    private let ean13: EAN13
+    
+    public init(ean13: EAN13) {
+        self.ean13 = ean13
+        super.init(frame: .zero)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        let barcodeStackView = UIStackView(ean13: ean13)
+        barcodeStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let numberLabel = UILabel()
+        numberLabel.text = ean13.value
+        numberLabel.textAlignment = .center
+        numberLabel.font = UIFont.systemFont(ofSize: 12)
+        numberLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let containerStackView = UIStackView(arrangedSubviews: [barcodeStackView, numberLabel])
+        containerStackView.axis = .vertical
+        containerStackView.spacing = 4
+        containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        addSubview(containerStackView)
+        
+        NSLayoutConstraint.activate([
+            containerStackView.topAnchor.constraint(equalTo: topAnchor),
+            containerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "EAN13View",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "EAN13View",
+            targets: ["EAN13View"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "EAN13View",
+            path: "EAN13View/Source",
+            publicHeadersPath: ".."
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 [![Build Status](https://travis-ci.org/dkpoulsen/EAN13View.svg?branch=master)](https://travis-ci.org/dkpoulsen/EAN13View)
 
+## Installation
+
+### Swift Package Manager
+
+Add EAN13View as a dependency in your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/dkpoulsen/EAN13View.git", from: "1.0.0")
+]
+```
+
+Or add it via Xcode:
+1. File → Add Packages
+2. Enter: `https://github.com/dkpoulsen/EAN13View.git`
+
+## Usage
+
 ### Barcode only
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 [![Build Status](https://travis-ci.org/dkpoulsen/EAN13View.svg?branch=master)](https://travis-ci.org/dkpoulsen/EAN13View)
 
+### Barcode only
+
 ```swift
         let ean = try! EAN13(value: "5901234123457")
         let view = UIStackView(ean13: ean)
 ```
+
+### Barcode with numeric display
+
+```swift
+        let ean = try! EAN13(value: "5901234123457")
+        let view = EAN13View(ean13: ean)
+```
+
 ![EAN13](barcode.png)

--- a/example/ViewController.swift
+++ b/example/ViewController.swift
@@ -15,14 +15,14 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
         let ean = try! EAN13(value: "5901234123457")
-        let view = UIStackView(ean13: ean)
+        let view = EAN13View(ean13: ean)
         view.translatesAutoresizingMaskIntoConstraints = false
 
         self.view.addSubview(view)
         view.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
         view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         view.widthAnchor.constraint(equalToConstant: 300).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 120).isActive = true
     }
 
 


### PR DESCRIPTION
- Expose value property in EAN13 struct for public access
- Add EAN13View class that displays barcode with numeric label below
- Maintain backward compatibility with existing UIStackView extension
- Update example to demonstrate new EAN13View usage
- Update README with both usage options